### PR TITLE
ENHANCE: Use more generic error message for branch format

### DIFF
--- a/pre_push/branch_format.rb
+++ b/pre_push/branch_format.rb
@@ -15,7 +15,7 @@ module Overcommit::Hook::PrePush
       if IGNORED.include?(ref)
         return nil
       elsif ref !~ /^[a-z]+\/[a-z0-9]+(?:-[a-z0-9]+)*$/
-        return "Remote ref should be of the form feature/something-new, not #{ref}"
+        return "Remote ref should be of the form 'tag/hyphen-separated-description', not '#{ref}'"
       elsif not TAGS.any? { |tag| ref.start_with? tag }
         return "Remote ref should start with one of: " + TAGS.join(" ")
       end


### PR DESCRIPTION
This change proposes a more generic example for the branch format error message - the current one makes it sound like the hook is complaining about the tag not being `feature` as opposed to complaining about the format of the ref name.