### PR TITLE
CONFIG: Relax line length check

### DIFF
--- a/pre_commit/resources/dstil_checkstyle.xml
+++ b/pre_commit/resources/dstil_checkstyle.xml
@@ -40,7 +40,7 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="100"/>
+            <property name="max" value="150"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>


### PR DESCRIPTION
This gets triggered a lot with Spring controller annotations, and we've all got massive monitors anyway.