### PR TITLE
QUALITY: Remove overly-pedantic CheckStyle rule

### DIFF
--- a/pre_commit/resources/dstil_checkstyle.xml
+++ b/pre_commit/resources/dstil_checkstyle.xml
@@ -157,7 +157,6 @@
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
-        <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>


### PR DESCRIPTION
Checks for distance between variable declaration and usage. Overly pedantic.