### PR TITLE
ENHANCE: Add TEMP and temp/ to allowed tags/branches

### DIFF
--- a/commit_msg/commit_tag.rb
+++ b/commit_msg/commit_tag.rb
@@ -1,7 +1,7 @@
 module Overcommit::Hook::CommitMsg
   # Ensures the commit message follows a specific format.
   class CommitTag < Base
-    TAGS = ['NEW', 'ENHANCE', 'FIX', 'LOOKS', 'SPEED', 'QUALITY', 'DOC', 'CONFIG', 'TEST']
+    TAGS = ['NEW', 'ENHANCE', 'FIX', 'LOOKS', 'SPEED', 'QUALITY', 'DOC', 'CONFIG', 'TEST', 'TEMP']
 
     def run
       error_msg = validate_pattern(commit_message_lines[0])

--- a/pre_push/branch_format.rb
+++ b/pre_push/branch_format.rb
@@ -1,6 +1,6 @@
 module Overcommit::Hook::PrePush
   class BranchFormat < Base
-    TAGS = ['feature', 'enhance', 'fix', 'looks', 'speed', 'quality', 'doc', 'config', 'test']
+    TAGS = ['feature', 'enhance', 'fix', 'looks', 'speed', 'quality', 'doc', 'config', 'test', 'temp']
     IGNORED = ['master', 'development']
 
     def run


### PR DESCRIPTION
Allows TEMP: as a commit tag and `temp/` as a branch prefix.